### PR TITLE
Content: Add ticket sale opening time (20.00) to April 15 listings

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Rogue Rope Camp"
 description: "An intimate rope gathering east of Ghent, west of Antwerp."
-lead: "Tue–Sun, Aug 4–9, 2026. Tickets on sale April 15, 2026."
+lead: "Tue–Sun, Aug 4–9, 2026. Tickets on sale April 15, 2026 at 20.00."
 layout: "hextra-home"
 toc: false
 ---
@@ -14,7 +14,7 @@ toc: false
     </p>
     <p class="rrc-home-intro-meta">
       <strong>Dates:</strong> Tue–Sun, Aug 4–9, 2026<br>
-      <strong>Ticket sales:</strong> April 15, 2026
+      <strong>Ticket sales:</strong> April 15, 2026 at 20.00
     </p>
     <div class="rrc-home-intro-actions">
       {{< hextra/hero-button text="Tickets & Participation" link="/docs/practical/tickets/" >}}

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -3,7 +3,7 @@ title: "Rogue Rope Camp"
 description: "Six-day intimate rope gathering in Belgium. Connection over performance, consent as sacred practice. Aug 4-9, 2026."
 lead: "A sanctuary for rope as ritual, connection over performance, and consent as sacred practice."
 date: 2026-03-28T00:00:00+00:00
-lastmod: 2026-04-01T00:00:00+00:00
+lastmod: 2026-04-08T00:00:00+00:00
 weight: 1
 toc: false
 ---
@@ -13,7 +13,7 @@ toc: false
 {{< callout type="info" >}}
 **Rogue Rope Camp 2026**  
 Tue–Sun, **Aug 4–9, 2026** (east of Ghent, west of Antwerp)  
-Tickets on sale **April 15, 2026**
+Tickets on sale **April 15, 2026 at 20.00**
 {{< /callout >}}
 
 ## New here? Welcome.

--- a/content/docs/practical/_index.md
+++ b/content/docs/practical/_index.md
@@ -4,7 +4,7 @@ description: "Logistics, preparation, and participation for Rogue Rope Camp 2026
 lead: "Everything you need to arrive prepared, grounded, and ready to participate."
 date: 2026-03-28T00:00:00+00:00
 weight: 3
-lastmod: 2026-04-01T00:00:00+00:00
+lastmod: 2026-04-08T00:00:00+00:00
 toc: false
 aliases:
   - /docs/practical/policies/
@@ -18,7 +18,7 @@ Build Day is part of the culture. It’s not about being handy, it’s about arr
 
 {{< callout type="info" >}}
 **Dates:** Tue–Sun, **Aug 4–9, 2026**  
-**Ticket sales:** **April 15, 2026**  
+**Ticket sales:** **April 15, 2026 at 20.00**  
 **Shop:** `https://shop.gogogonzo.be/RRC26/`  
 **Contact:** `contact@roguerope.be`
 {{< /callout >}}

--- a/content/docs/practical/tickets.md
+++ b/content/docs/practical/tickets.md
@@ -3,7 +3,7 @@ title: Tickets
 description: "How ticketing works and how to secure your spot."
 lead: "Read first, then buy: a slow yes beats a rushed one."
 date: 2024-04-06T13:37:00+00:00
-lastmod: 2026-04-01T00:00:00+00:00
+lastmod: 2026-04-08T00:00:00+00:00
 aliases:
   - /docs/practical/participation/
 images: []
@@ -21,7 +21,7 @@ This isn’t just about clicking “buy.” It’s about saying yes, with your w
 - Dates: Tue–Sun, Aug 4–9, 2026
 - Location: East of Ghent, west of Antwerp
 - Ticket price: 200 €
-- Ticket sales open: Wednesday, April 15, 2026
+- Ticket sales open: Wednesday, April 15, 2026 at 20.00
 
 ![Tickets page illustration for Rogue Rope Camp.](/images/rrc26/mj/hansf_Hero_illustration_for_the_Tickets_page_of_Rogue_Rope_Ca_d4c6b482-c5df-4e9b-99c7-a19669312130_3.png)
 
@@ -69,7 +69,7 @@ We’ll meet you where we can.
 ## Step 3: Buy Your Ticket
 
 If it’s a yes — beautiful.  
-Tickets go on sale **Wednesday, April 15, 2026**.
+Tickets go on sale **Wednesday, April 15, 2026 at 20.00**.
 
 Tickets cost **200 €**.
 


### PR DESCRIPTION
### Motivation
- Ensure the site communicates the exact start time for ticket sales so visitors know tickets open at `20.00` on April 15, 2026.
- Keep public-facing pages and meta copy consistent across the homepage, docs landing, practical landing, and tickets page.

### Description
- Updated ticket sale copy to include the time `20.00` in `content/_index.md`, `content/docs/_index.md`, `content/docs/practical/_index.md`, and `content/docs/practical/tickets.md`.
- Bumped `lastmod` metadata to `2026-04-08T00:00:00+00:00` in the edited docs files to reflect the content change.
- Changes were committed with the message `Content: Add ticket sale time to April 15 listings`.

### Testing
- Attempted to run the production-equivalent Hugo check with `hugo --gc --minify --printPathWarnings`, which failed in this environment because `hugo` is not installed.
- There are no other repository automated tests available to run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62ee12424832a9217faf1f2f37702)