### PR TITLE
Content: Remove 'biodegradable' qualifier from hygiene packing list

### DIFF
--- a/content/docs/practical/things-to-bring.md
+++ b/content/docs/practical/things-to-bring.md
@@ -2,7 +2,7 @@
 title: Things to Bring
 description: "A practical packing list for six days in the field."
 date: 2024-04-06T13:37:00+00:00
-lastmod: 2026-04-01T00:00:00+00:00
+lastmod: 2026-07-18T00:00:00+00:00
 images: []
 weight: 50
 toc: true
@@ -44,7 +44,7 @@ lead: "The essentials, so you can arrive comfortable."
 
 ### Hygiene & Health
 
-- Biodegradable soap + shampoo
+- Soap + shampoo
 - Toothbrush + toothpaste
 - Quick-dry towel
 - Hand sanitizer

--- a/full_content_overview.md
+++ b/full_content_overview.md
@@ -2997,7 +2997,7 @@ Make your space comfortable for the duration:
 
 Daily necessities for communal living:
 
-- [ ] Biodegradable soap + shampoo
+- [ ] Soap + shampoo
 - [ ] Toothbrush + toothpaste
 - [ ] Quick-dry towel
 - [ ] Hand sanitizer


### PR DESCRIPTION
### Motivation
- Remove the “biodegradable” qualifier from the hygiene packing list so the site references standard soap and shampoo and keep the generated content overview consistent, also bumping the page `lastmod` to reflect the edit.

### Description
- Replaced "Biodegradable soap + shampoo" with "Soap + shampoo" in `content/docs/practical/things-to-bring.md` and the tracked `full_content_overview.md`, and updated the `lastmod` date on the page.

### Testing
- Ran `git diff --check` which passed, and attempted `hugo --gc --minify --printPathWarnings` but it could not run because `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bcaab2d00832abe1f60ae61a301ca)